### PR TITLE
Remove times(other: T) from Quantity

### DIFF
--- a/core/src/main/kotlin/dev/nextftc/core/units/Quantity.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/units/Quantity.kt
@@ -33,7 +33,6 @@ abstract class Quantity<T : Quantity<T>> {
 
     operator fun plus(other: T): T = newInstance(value + other.value)
     operator fun minus(other: T): T = newInstance(value - other.value)
-    operator fun times(other: T): T = newInstance(value * other.value)
     operator fun times(scalar: Double): T = newInstance(value * scalar)
     operator fun times(scalar: Int): T = newInstance(value * scalar)
     operator fun div(other: T): Double = value / other.value


### PR DESCRIPTION
Leads to incorrect math because `quantity * quantity` should result in `quantity ^ 2` but packaging it into a `quantity` gives it incorrect behavior when using units other than the base unit.