### PR TITLE
Remove Java Duration in favor of Strings for Java users

### DIFF
--- a/core/src/main/kotlin/dev/nextftc/core/commands/Command.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/Command.kt
@@ -25,11 +25,8 @@ import dev.nextftc.core.commands.groups.SequentialGroup
 import dev.nextftc.core.commands.utility.ForcedParallelCommand
 import dev.nextftc.core.commands.utility.PerpetualCommand
 import dev.nextftc.core.commands.delays.Delay
-import dev.nextftc.core.subsystems.Subsystem
-import dev.nextftc.core.units.JDuration
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toKotlinDuration
 
 /**
  * A discrete unit of functionality that runs simultaneous to all other commands.
@@ -193,7 +190,7 @@ abstract class Command : Runnable {
      */
     fun endAfter(time: Double) = endAfter(time.seconds)
 
-    fun endAfter(time: JDuration) = endAfter(time.toKotlinDuration())
+    fun endAfter(time: String) = endAfter(Duration.parse(time.replace("\\s".toRegex(), "")))
 
     /**
      * Returns a [SequentialGroup] with this command and an arbitrary number of other commands
@@ -242,7 +239,7 @@ abstract class Command : Runnable {
      */
     fun afterTime(time: Double) = afterTime(time.seconds)
 
-    fun afterTime(time: JDuration) = afterTime(time.toKotlinDuration())
+    fun afterTime(time: String) = afterTime(Duration.parse(time.replace("\\s".toRegex(), "")))
 
     /**
      * Returns a [SequentialGroup] with this command and then a [Delay]
@@ -259,7 +256,7 @@ abstract class Command : Runnable {
      */
     fun thenWait(time: Double) = thenWait(time.seconds)
 
-    fun thenWait(time: JDuration) = thenWait(time.toKotlinDuration())
+    fun thenWait(time: String) = thenWait(Duration.parse(time.replace("\\s".toRegex(), "")))
 
     /**
      * Returns a [ParallelDeadlineGroup] with this command and the passed command as the deadline

--- a/core/src/main/kotlin/dev/nextftc/core/commands/Command.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/Command.kt
@@ -25,6 +25,7 @@ import dev.nextftc.core.commands.groups.SequentialGroup
 import dev.nextftc.core.commands.utility.ForcedParallelCommand
 import dev.nextftc.core.commands.utility.PerpetualCommand
 import dev.nextftc.core.commands.delays.Delay
+import dev.nextftc.core.units.stringToDuration
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -190,7 +191,7 @@ abstract class Command : Runnable {
      */
     fun endAfter(time: Double) = endAfter(time.seconds)
 
-    fun endAfter(time: String) = endAfter(Duration.parse(time.replace("\\s".toRegex(), "")))
+    fun endAfter(time: String) = endAfter(stringToDuration(time))
 
     /**
      * Returns a [SequentialGroup] with this command and an arbitrary number of other commands
@@ -239,7 +240,7 @@ abstract class Command : Runnable {
      */
     fun afterTime(time: Double) = afterTime(time.seconds)
 
-    fun afterTime(time: String) = afterTime(Duration.parse(time.replace("\\s".toRegex(), "")))
+    fun afterTime(time: String) = afterTime(stringToDuration(time))
 
     /**
      * Returns a [SequentialGroup] with this command and then a [Delay]
@@ -256,7 +257,7 @@ abstract class Command : Runnable {
      */
     fun thenWait(time: Double) = thenWait(time.seconds)
 
-    fun thenWait(time: String) = thenWait(Duration.parse(time.replace("\\s".toRegex(), "")))
+    fun thenWait(time: String) = thenWait(stringToDuration(time))
 
     /**
      * Returns a [ParallelDeadlineGroup] with this command and the passed command as the deadline

--- a/core/src/main/kotlin/dev/nextftc/core/commands/Command.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/Command.kt
@@ -25,7 +25,7 @@ import dev.nextftc.core.commands.groups.SequentialGroup
 import dev.nextftc.core.commands.utility.ForcedParallelCommand
 import dev.nextftc.core.commands.utility.PerpetualCommand
 import dev.nextftc.core.commands.delays.Delay
-import dev.nextftc.core.units.stringToDuration
+import dev.nextftc.core.units.parseDuration
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -191,7 +191,7 @@ abstract class Command : Runnable {
      */
     fun endAfter(time: Double) = endAfter(time.seconds)
 
-    fun endAfter(time: String) = endAfter(stringToDuration(time))
+    fun endAfter(time: String) = endAfter(parseDuration(time))
 
     /**
      * Returns a [SequentialGroup] with this command and an arbitrary number of other commands
@@ -240,7 +240,7 @@ abstract class Command : Runnable {
      */
     fun afterTime(time: Double) = afterTime(time.seconds)
 
-    fun afterTime(time: String) = afterTime(stringToDuration(time))
+    fun afterTime(time: String) = afterTime(parseDuration(time))
 
     /**
      * Returns a [SequentialGroup] with this command and then a [Delay]
@@ -257,7 +257,7 @@ abstract class Command : Runnable {
      */
     fun thenWait(time: Double) = thenWait(time.seconds)
 
-    fun thenWait(time: String) = thenWait(stringToDuration(time))
+    fun thenWait(time: String) = thenWait(parseDuration(time))
 
     /**
      * Returns a [ParallelDeadlineGroup] with this command and the passed command as the deadline

--- a/core/src/main/kotlin/dev/nextftc/core/commands/delays/Delay.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/delays/Delay.kt
@@ -20,7 +20,7 @@ package dev.nextftc.core.commands.delays
 
 import dev.nextftc.core.commands.Command
 import dev.nextftc.core.commands.groups.ParallelGroup
-import dev.nextftc.core.units.stringToDuration
+import dev.nextftc.core.units.parseDuration
 import kotlin.time.ComparableTimeMark
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -48,7 +48,7 @@ class Delay(
     /**
      * @param time the desired duration of this command as a string
      */
-    constructor(time: String) : this(stringToDuration(time))
+    constructor(time: String) : this(parseDuration(time))
 
     private lateinit var startTime: ComparableTimeMark
 

--- a/core/src/main/kotlin/dev/nextftc/core/commands/delays/Delay.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/delays/Delay.kt
@@ -20,13 +20,11 @@ package dev.nextftc.core.commands.delays
 
 import dev.nextftc.core.commands.Command
 import dev.nextftc.core.commands.groups.ParallelGroup
-import dev.nextftc.core.units.JDuration
 import kotlin.time.ComparableTimeMark
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 import kotlin.time.TimeSource.Monotonic.markNow
-import kotlin.time.toKotlinDuration
 
 /**
  * A [Command] that does nothing except wait until a certain amount of time has passed. Like all
@@ -46,7 +44,10 @@ class Delay(
      */
     constructor(time: Double) : this(time.seconds)
 
-    constructor(time: JDuration) : this(time.toKotlinDuration())
+    /**
+     * @param time the desired duration of this command as a string
+     */
+    constructor(time: String) : this(Duration.parse(time.replace("\\s".toRegex(), "")))
 
     private lateinit var startTime: ComparableTimeMark
 

--- a/core/src/main/kotlin/dev/nextftc/core/commands/delays/Delay.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/delays/Delay.kt
@@ -20,6 +20,7 @@ package dev.nextftc.core.commands.delays
 
 import dev.nextftc.core.commands.Command
 import dev.nextftc.core.commands.groups.ParallelGroup
+import dev.nextftc.core.units.stringToDuration
 import kotlin.time.ComparableTimeMark
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -47,7 +48,7 @@ class Delay(
     /**
      * @param time the desired duration of this command as a string
      */
-    constructor(time: String) : this(Duration.parse(time.replace("\\s".toRegex(), "")))
+    constructor(time: String) : this(stringToDuration(time))
 
     private lateinit var startTime: ComparableTimeMark
 

--- a/core/src/main/kotlin/dev/nextftc/core/units/Duration.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/units/Duration.kt
@@ -3,7 +3,7 @@ package dev.nextftc.core.units
 import kotlin.time.Duration
 
 /**
- * Parses a provided string into a Duration. Differs from `Duration#parse` because it ignores spaces
+ * Parses a provided string into a Duration. Differs from `Duration#parse` because it ignores spaces.
  */
 fun parseDuration(string: String): Duration {
     return Duration.parse(string.replace("\\s".toRegex(), ""))

--- a/core/src/main/kotlin/dev/nextftc/core/units/Duration.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/units/Duration.kt
@@ -2,6 +2,9 @@ package dev.nextftc.core.units
 
 import kotlin.time.Duration
 
-fun stringToDuration(string: String): Duration {
+/**
+ * Parses a provided string into a Duration. Differs from `Duration#parse` because it ignores spaces
+ */
+fun parseDuration(string: String): Duration {
     return Duration.parse(string.replace("\\s".toRegex(), ""))
 }

--- a/core/src/main/kotlin/dev/nextftc/core/units/Duration.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/units/Duration.kt
@@ -1,0 +1,7 @@
+package dev.nextftc.core.units
+
+import kotlin.time.Duration
+
+fun stringToDuration(string: String): Duration {
+    return Duration.parse(string.replace("\\s".toRegex(), ""))
+}

--- a/core/src/main/kotlin/dev/nextftc/core/units/JDuration.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/units/JDuration.kt
@@ -1,3 +1,0 @@
-package dev.nextftc.core.units
-
-typealias JDuration = java.time.Duration

--- a/hardware/src/main/kotlin/dev/nextftc/hardware/impl/VoltageCompensatingMotor.kt
+++ b/hardware/src/main/kotlin/dev/nextftc/hardware/impl/VoltageCompensatingMotor.kt
@@ -1,5 +1,6 @@
 package dev.nextftc.hardware.impl
 
+import dev.nextftc.core.units.stringToDuration
 import dev.nextftc.ftc.ActiveOpMode
 import dev.nextftc.hardware.controllable.Controllable
 import kotlin.properties.Delegates
@@ -26,7 +27,7 @@ class VoltageCompensatingMotor(
         controllable: Controllable,
         voltageCacheTime: String,
         nominalVoltage: Double = 12.0
-    ) : this(controllable, Duration.parse(voltageCacheTime.replace("\\s".toRegex(), "")), nominalVoltage)
+    ) : this(controllable, stringToDuration(voltageCacheTime), nominalVoltage)
 
     private val voltageSensor by lazy { ActiveOpMode.hardwareMap.voltageSensor.first() }
 

--- a/hardware/src/main/kotlin/dev/nextftc/hardware/impl/VoltageCompensatingMotor.kt
+++ b/hardware/src/main/kotlin/dev/nextftc/hardware/impl/VoltageCompensatingMotor.kt
@@ -1,6 +1,6 @@
 package dev.nextftc.hardware.impl
 
-import dev.nextftc.core.units.stringToDuration
+import dev.nextftc.core.units.parseDuration
 import dev.nextftc.ftc.ActiveOpMode
 import dev.nextftc.hardware.controllable.Controllable
 import kotlin.properties.Delegates
@@ -27,7 +27,7 @@ class VoltageCompensatingMotor(
         controllable: Controllable,
         voltageCacheTime: String,
         nominalVoltage: Double = 12.0
-    ) : this(controllable, stringToDuration(voltageCacheTime), nominalVoltage)
+    ) : this(controllable, parseDuration(voltageCacheTime), nominalVoltage)
 
     private val voltageSensor by lazy { ActiveOpMode.hardwareMap.voltageSensor.first() }
 

--- a/hardware/src/main/kotlin/dev/nextftc/hardware/impl/VoltageCompensatingMotor.kt
+++ b/hardware/src/main/kotlin/dev/nextftc/hardware/impl/VoltageCompensatingMotor.kt
@@ -1,15 +1,12 @@
 package dev.nextftc.hardware.impl
 
-import dev.nextftc.core.units.JDuration
 import dev.nextftc.ftc.ActiveOpMode
 import dev.nextftc.hardware.controllable.Controllable
 import kotlin.properties.Delegates
 import kotlin.time.ComparableTimeMark
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource.Monotonic.markNow
-import kotlin.time.toKotlinDuration
 
 class VoltageCompensatingMotor(
     private val controllable: Controllable,
@@ -27,9 +24,9 @@ class VoltageCompensatingMotor(
     @JvmOverloads
     constructor(
         controllable: Controllable,
-        voltageCacheTime: JDuration,
+        voltageCacheTime: String,
         nominalVoltage: Double = 12.0
-    ) : this(controllable, voltageCacheTime.toKotlinDuration(), nominalVoltage)
+    ) : this(controllable, Duration.parse(voltageCacheTime.replace("\\s".toRegex(), "")), nominalVoltage)
 
     private val voltageSensor by lazy { ActiveOpMode.hardwareMap.voltageSensor.first() }
 


### PR DESCRIPTION
Instead of using Java Duration (which isn't compatible with Android SDK version 24), instead use Strings. This PR adds String-based overloads to methods that require a Duration. Strings have spaces removed and then are passed to Duration.parse.