### PR TITLE
fix: update hardwareMap initialization 

### DIFF
--- a/ftc/src/main/kotlin/dev/nextftc/ftc/ActiveOpMode.kt
+++ b/ftc/src/main/kotlin/dev/nextftc/ftc/ActiveOpMode.kt
@@ -84,7 +84,7 @@ object ActiveOpMode : OpModeManagerNotifier.Notifications {
     @JvmStatic
     fun register(context: Context, eventLoop: FtcEventLoop) {
         eventLoop.opModeManager.registerListener(this)
-        hardwareMap = eventLoop.opModeManager.hardwareMap
+        hardwareMap = HardwareMap(context, eventLoop.opModeManager)
     }
 
     override fun onOpModePreInit(opMode: OpMode?) {


### PR DESCRIPTION
this uses HardwareMap constructor instead of obtaining the null one from opmodemanagerimpl 